### PR TITLE
fix: add missing unique key to server settings card in SettingsPage

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -302,8 +302,10 @@ export default function SettingsPage() {
               <div className="flex flex-col gap-2">
                 {config &&
                   Object.entries(config.mcpServers).map(
-                    ([name, serverConfig]) =>
-                      renderServerCard(name, serverConfig, "mcp")
+                    ([name, serverConfig]) => 
+                      <div key={`server-config-card-${name}`}>
+                        {renderServerCard(name, serverConfig, "mcp")}
+                      </div>
                   )}
                 {!config && (
                   <div className="bg-default-50 p-4 rounded-lg">


### PR DESCRIPTION
While trying out the project found a minor error in the Systems settings Page, it had a missing unique key warning from a react component. Quick fix ;) 